### PR TITLE
Helper Methods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
       "error",
       {
         "ObjectPattern": {
-          "minProperties": 6
+          "minProperties": 8
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![Cover](/.github/images/cover.png)
 
 # Firstclasspostcodes
-The Firstclasspostcodes Javascript is compatible with both Node.JS and Browsers. An identical API is provided for both the client and server side.
+The Firstclasspostcodes Javascript library is compatible with both Node.JS and Browsers. 
+
+An identical API is provided for both the client and server side.
 
 ## Documentation
 See [@firstclasspostcodes/js API docs](https://docs.firstclasspostcodes.com/js/getting-started) for detailed usage and examples.
@@ -113,7 +115,7 @@ $ npm run lint
 $ npm test
 ```
 
-We use [Cypress]() to ensure that our library is working correctly within the browser, this can be executed locally using:
+We use [Cypress](https://www.cypress.io/) to ensure that our library is working correctly inside the browser, this can be executed locally using:
 
 ```
 $ npm run cypress

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -16,6 +16,10 @@ class Firstclasspostcodes {
     this.on('error', (err) => this.debug('Error: %o', err));
   }
 
+  get isGeoJson() {
+    return this.config.content === 'geo+json';
+  }
+
   async request(params = {}) {
     const { key } = this;
     const { qs, path, method = 'GET' } = params;
@@ -53,14 +57,14 @@ class Firstclasspostcodes {
     this.debug('Request parameters: %o', requestEvent);
     this.emit('request', requestEvent);
 
-    const response = await this.withRequestErrorHandling(() => this.fetch(url, request));
+    const result = await this.withRequestErrorHandling(() => this.fetch(url, request));
 
-    const json = await response.json();
+    const data = await result.json();
 
-    this.debug('Received response: %o', json);
-    this.emit('response', json);
+    this.debug('Received response: %o', data);
+    this.emit('response', data);
 
-    return json;
+    return data;
   }
 
   async withRequestErrorHandling(fn) {

--- a/lib/operations/getLookup.js
+++ b/lib/operations/getLookup.js
@@ -1,0 +1,76 @@
+const { ParameterValidationError } = require('./errors');
+
+const OPERATION_URL = 'https://docs.firstclasspostcodes.com/operation/getLookup';
+
+const OPERATION_PATH = '/lookup';
+
+const within = (min, val, max) => min <= val && val <= max;
+
+const validate = (latitude, longitude) => (
+  within(-90, latitude, 90) && within(-180, longitude, 180)
+);
+
+module.exports = {
+  async getLookup(options = {}) {
+    let errorObj;
+
+    if (!options.latitude || !options.longitude) {
+      errorObj = {
+        docUrl: OPERATION_URL,
+        message: `
+          Missing required parameters, expected { latitude, longitude }.
+          Received: ${JSON.stringify(options)}
+        `,
+      };
+    }
+
+    const latitude = parseFloat(options.latitude, 10);
+    const longitude = parseFloat(options.longitude, 10);
+    const radius = parseFloat((options.radius || 0.1), 10);
+
+    if (Number.isNaN(Number(radius)) || !within(0.0, radius, 5.0)) {
+      errorObj = {
+        docUrl: OPERATION_URL,
+        message: `
+          Parameter "radius" is invalid, should be between 0.0 and 5.0. 
+          Received: ${radius}
+        `,
+      };
+    }
+
+    if (
+      Number.isNaN(Number(latitude))
+      || Number.isNaN(Number(longitude))
+      || !validate(latitude, longitude)) {
+      errorObj = {
+        docUrl: OPERATION_URL,
+        message: `
+          Parameters "latitude" or "longitude" are invalid.
+          Received: ${JSON.stringify(options)}
+        `,
+      };
+    }
+
+    const params = {
+      path: OPERATION_PATH,
+      qs: {
+        latitude,
+        longitude,
+        radius,
+      },
+    };
+
+    this.debug(`Executing operation getLookup (${OPERATION_PATH}): %o`, params);
+
+    this.emit('operation:getLookup', params);
+
+    if (errorObj) {
+      const error = new ParameterValidationError(errorObj);
+      this.debug('Encountered ParameterValidationError: %o', errorObj);
+      this.emit('error', error);
+      throw error;
+    }
+
+    return this.request(params);
+  },
+};

--- a/lib/operations/getLookup.test.js
+++ b/lib/operations/getLookup.test.js
@@ -1,0 +1,171 @@
+const callable = require('./getLookup');
+const { ParameterValidationError } = require('./errors');
+
+describe('#getLookup', () => {
+  let testClass;
+
+  beforeEach(() => {
+    const TestClass = class {};
+
+    const classMethods = {
+      emit: jest.fn(),
+      debug: jest.fn(),
+      request: jest.fn(),
+      isGeoJson: false,
+    };
+
+    Object.assign(TestClass.prototype, classMethods, callable);
+
+    testClass = new TestClass();
+  });
+
+  it('it is a function', () => (
+    expect(testClass.getLookup).toEqual(expect.any(Function))
+  ));
+
+  describe('when the request is valid', () => {
+    let options;
+
+    beforeEach(() => {
+      options = {
+        latitude: 52.02,
+        longitude: -0.24,
+        radius: 0.2,
+      };
+    });
+
+    const testResponseBody = { a: 1 };
+
+    it('resolves with the correct response', async () => {
+      const expectedParams = expect.objectContaining({
+        path: expect.stringMatching(/^\/[a-z]+$/),
+        qs: expect.objectContaining(options),
+      });
+
+      testClass.request.mockImplementationOnce(async (params) => {
+        expect(params).toEqual(expectedParams);
+        return testResponseBody;
+      });
+
+      const response = await testClass.getLookup(options);
+
+      expect(response).toBe(testResponseBody);
+
+      expect(testClass.emit).toHaveBeenNthCalledWith(1, 'operation:getLookup', expectedParams);
+    });
+  });
+
+  describe('when the request is invalid', () => {
+    let options;
+
+    describe('when there are no request options', () => {
+      it('rejects with an error', () => (
+        expect(testClass.getLookup()).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the latitude is invalid', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 'invalid',
+          longitude: -0.24,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the latitude is incorrect', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 1234567,
+          longitude: -0.24,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the latitude is missing', () => {
+      beforeEach(() => {
+        options = {
+          longitude: -0.24,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the longitude is invalid', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 52.56,
+          longitude: 'invalid',
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the longitude is incorrect', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 52.56,
+          longitude: -1234,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the longitude is missing', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 52.56,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the radius is invalid', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 52.56,
+          longitude: -0.25,
+          radius: 'invalid',
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+
+    describe('when the radius is incorrect', () => {
+      beforeEach(() => {
+        options = {
+          latitude: 52.56,
+          longitude: -0.25,
+          radius: 12345,
+        };
+      });
+
+      it('rejects with an error', () => (
+        expect(testClass.getLookup(options)).rejects.toThrow(ParameterValidationError)
+      ));
+    });
+  });
+});

--- a/lib/operations/getPostcode.js
+++ b/lib/operations/getPostcode.js
@@ -1,3 +1,4 @@
+const { listAddresses, formatAddress } = require('./methods');
 const { ParameterValidationError } = require('./errors');
 
 const OPERATION_URL = 'https://docs.firstclasspostcodes.com/operation/getPostcode';
@@ -33,6 +34,12 @@ module.exports = {
       throw error;
     }
 
-    return this.request(params);
+    const responseObject = await this.request(params);
+
+    if (!this.isGeoJson) {
+      Object.assign(responseObject, { listAddresses, formatAddress });
+    }
+
+    return responseObject;
   },
 };

--- a/lib/operations/getPostcode.test.js
+++ b/lib/operations/getPostcode.test.js
@@ -11,6 +11,7 @@ describe('#getPostcode', () => {
       emit: jest.fn(),
       debug: jest.fn(),
       request: jest.fn(),
+      isGeoJson: false,
     };
 
     Object.assign(TestClass.prototype, classMethods, callable);
@@ -39,7 +40,12 @@ describe('#getPostcode', () => {
         expect(params).toEqual(expectedParams);
         return testResponseBody;
       });
-      await expect(testClass.getPostcode('test')).resolves.toBe(testResponseBody);
+      const response = await testClass.getPostcode('test');
+      expect(response).toBe(testResponseBody);
+      expect(response).toEqual(expect.objectContaining({
+        formatAddress: expect.any(Function),
+        listAddresses: expect.any(Function),
+      }));
       expect(testClass.emit).toHaveBeenNthCalledWith(1, 'operation:getPostcode', expectedParams);
     });
   });

--- a/lib/operations/index.js
+++ b/lib/operations/index.js
@@ -1,5 +1,7 @@
 const { getPostcode } = require('./getPostcode');
+const { getLookup } = require('./getLookup');
 
 module.exports = {
   getPostcode,
+  getLookup,
 };

--- a/lib/operations/methods/formatAddress.js
+++ b/lib/operations/methods/formatAddress.js
@@ -1,0 +1,50 @@
+const RECOGNISED_TYPE_REGEX = /^(postcode|streets|numbers)$/;
+
+const join = (...parts) => parts.filter(Boolean).join(', ');
+
+module.exports = {
+  formatAddress(index) {
+    const [type, element] = index.split(':');
+
+    if (!RECOGNISED_TYPE_REGEX.test(type)) {
+      throw new Error(`Received unrecognised type "${type}"`);
+    }
+
+    const typeMismatchError = new Error(`Received index "${index}" but no ${type} data.`);
+
+    const { city, locality, county, region, postcode, country } = this;
+
+    const data = {
+      locality: city || locality,
+      region: county || region,
+      postcode,
+      country,
+    };
+
+    if (type === 'postcode') {
+      return data;
+    }
+
+    const { [type]: list } = this;
+
+    if (!list || list.length === 0) {
+      throw typeMismatchError;
+    }
+
+    const component = list[element];
+
+    let address;
+
+    if (type === 'numbers') {
+      const { number, street, building } = component;
+      address = join(number, building, street);
+    } else {
+      address = component;
+    }
+
+    return {
+      address,
+      ...data,
+    };
+  },
+};

--- a/lib/operations/methods/formatAddress.test.js
+++ b/lib/operations/methods/formatAddress.test.js
@@ -1,0 +1,122 @@
+const callable = require('./formatAddress');
+
+describe('#formatAddress', () => {
+  let testClass;
+
+  let index;
+
+  beforeEach(() => {
+    const TestClass = class {};
+
+    Object.assign(TestClass.prototype, callable);
+
+    testClass = new TestClass();
+  });
+
+  beforeEach(() => {
+    Object.assign(testClass, {
+      numbers: [
+        {
+          number: 1,
+          street: 'A Street',
+        },
+        {
+          number: 'Flat A',
+          building: 'Crescent',
+          street: 'A Street',
+        },
+      ],
+      streets: [
+        'A Street',
+        'B Avenue',
+      ],
+      locality: 'locality',
+      city: 'city',
+      county: 'county',
+      region: 'region',
+      country: 'country',
+      postcode: 'postcode',
+    });
+  });
+
+  it('it is a function', () => (
+    expect(testClass.formatAddress).toEqual(expect.any(Function))
+  ));
+
+  describe('when the type is invalid', () => {
+    beforeEach(() => {
+      index = 'drtyhbvfde:0';
+    });
+
+    it('throws an error', () => (
+      expect(() => testClass.formatAddress(index)).toThrow(Error)
+    ));
+  });
+
+  describe('when the "postcode" type is passed in', () => {
+    beforeEach(() => {
+      index = 'postcode:0';
+    });
+
+    it('returns a formatted postcode', () => (
+      expect(testClass.formatAddress(index)).toEqual(expect.objectContaining({
+        locality: 'city',
+        region: 'county',
+        postcode: 'postcode',
+        country: 'country',
+      }))
+    ));
+  });
+
+  describe('when the "streets" type is passed in', () => {
+    beforeEach(() => {
+      index = 'streets:1';
+    });
+
+    it('returns a formatted street', () => (
+      expect(testClass.formatAddress(index)).toEqual(expect.objectContaining({
+        address: 'B Avenue',
+        locality: 'city',
+        region: 'county',
+        postcode: 'postcode',
+        country: 'country',
+      }))
+    ));
+
+    describe('when there are no streets', () => {
+      beforeEach(() => {
+        testClass.streets = null;
+      });
+
+      it('throws an error', () => (
+        expect(() => testClass.formatAddress(index)).toThrow(Error)
+      ));
+    });
+  });
+
+  describe('when the "numbers" type is passed in', () => {
+    beforeEach(() => {
+      index = 'numbers:1';
+    });
+
+    it('returns a formatted number', () => (
+      expect(testClass.formatAddress(index)).toEqual(expect.objectContaining({
+        address: 'Flat A, Crescent, A Street',
+        locality: 'city',
+        region: 'county',
+        postcode: 'postcode',
+        country: 'country',
+      }))
+    ));
+
+    describe('when there are no numbers', () => {
+      beforeEach(() => {
+        testClass.numbers = null;
+      });
+
+      it('throws an error', () => (
+        expect(() => testClass.formatAddress(index)).toThrow(Error)
+      ));
+    });
+  });
+});

--- a/lib/operations/methods/index.js
+++ b/lib/operations/methods/index.js
@@ -1,0 +1,7 @@
+const { listAddresses } = require('./listAddresses');
+const { formatAddress } = require('./formatAddress');
+
+module.exports = {
+  listAddresses,
+  formatAddress,
+};

--- a/lib/operations/methods/listAddresses.js
+++ b/lib/operations/methods/listAddresses.js
@@ -1,0 +1,36 @@
+const join = (...parts) => parts.filter(Boolean).join(', ');
+
+const NUMBERS_TYPE = 'numbers';
+
+const STREETS_TYPE = 'streets';
+
+const POSTCODE_TYPE = 'postcode';
+
+module.exports = {
+  listAddresses() {
+    const { numbers, postcode, streets, city, locality } = this;
+
+    const suffix = join(city || locality, postcode);
+
+    if (numbers && numbers.length > 0) {
+      return numbers.map(({ number, street, building }, index) => [
+        `${NUMBERS_TYPE}:${index}`,
+        join(number, building, street, suffix),
+      ]);
+    }
+
+    if (streets && streets.length > 0) {
+      return streets.map((street, index) => [
+        `${STREETS_TYPE}:${index}`,
+        join(street, suffix),
+      ]);
+    }
+
+    const postcodeData = [
+      `${POSTCODE_TYPE}:0`,
+      suffix,
+    ];
+
+    return [postcodeData];
+  },
+};

--- a/lib/operations/methods/listAddresses.test.js
+++ b/lib/operations/methods/listAddresses.test.js
@@ -1,0 +1,102 @@
+const callable = require('./listAddresses');
+
+describe('#listAddresses', () => {
+  let testClass;
+
+  beforeEach(() => {
+    const TestClass = class {};
+
+    Object.assign(TestClass.prototype, callable);
+
+    testClass = new TestClass();
+  });
+
+  it('it is a function', () => (
+    expect(testClass.listAddresses).toEqual(expect.any(Function))
+  ));
+
+  describe('when there are no numbers or streets', () => {
+    beforeEach(() => {
+      Object.assign(testClass, {
+        numbers: [],
+        streets: [],
+        locality: 'locality',
+        city: 'city',
+        postcode: 'postcode',
+      });
+    });
+
+    it('returns a postcode option', () => (
+      expect(testClass.listAddresses()).toEqual(
+        expect.arrayContaining([
+          expect.arrayContaining([
+            expect.stringMatching('postcode:0'),
+            expect.stringMatching('city, postcode'),
+          ]),
+        ]),
+      )
+    ));
+  });
+
+  describe('when there are only streets', () => {
+    beforeEach(() => {
+      Object.assign(testClass, {
+        numbers: [],
+        streets: ['A Street', 'B Avenue'],
+        locality: 'locality',
+        city: 'city',
+        postcode: 'postcode',
+      });
+    });
+
+    it('returns equal number of street options', () => {
+      const data = testClass.listAddresses();
+      expect(data).toEqual([
+        expect.arrayContaining([
+          expect.stringMatching('streets:0'),
+          expect.stringMatching('A Street, city, postcode'),
+        ]),
+        expect.arrayContaining([
+          expect.stringMatching('streets:1'),
+          expect.stringMatching('B Avenue, city, postcode'),
+        ]),
+      ]);
+    });
+  });
+
+  describe('when there are streets and numbers', () => {
+    beforeEach(() => {
+      Object.assign(testClass, {
+        numbers: [
+          {
+            number: 1,
+            street: 'A Street',
+          },
+          {
+            number: 'Flat A',
+            building: 'Crescent',
+            street: 'A Street',
+          },
+        ],
+        streets: ['A Street', 'B Avenue'],
+        locality: 'locality',
+        city: 'city',
+        postcode: 'postcode',
+      });
+    });
+
+    it('returns equal number of street options', () => {
+      const data = testClass.listAddresses();
+      expect(data).toEqual([
+        expect.arrayContaining([
+          expect.stringMatching('numbers:0'),
+          expect.stringMatching('1, A Street, city, postcode'),
+        ]),
+        expect.arrayContaining([
+          expect.stringMatching('numbers:1'),
+          expect.stringMatching('Flat A, Crescent, A Street, city, postcode'),
+        ]),
+      ]);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "browser": "dist/browser/index.js",
   "browserslist": [
     "> 1%",
+    "IE 11",
     "not dead"
   ],
   "size-limit": [
@@ -40,6 +41,7 @@
       "engines": {
         "browsers": [
           "> 1%",
+          "IE 11",
           "not dead"
         ]
       }
@@ -49,7 +51,7 @@
     "commit": "npx git-cz",
     "build": "parcel build lib/index.js --target main --target module",
     "lint": "eslint '**/*.js'",
-    "test": "jest **/*.test.js --coverage",
+    "test": "jest --coverage",
     "cypress": "cypress run --headless",
     "postbuild": "parcel build lib/browser.js --target browser && size-limit",
     "start": "parcel serve index.html"


### PR DESCRIPTION
This work implements some helper methods on relevant API responses for the getPostcode operation. It allows the easy formatting and listing of addresses that have been returned.